### PR TITLE
Refactor prints to logging

### DIFF
--- a/CrashTracker.py
+++ b/CrashTracker.py
@@ -3,7 +3,10 @@
 import os
 import json
 import time
+import logging
 from colorama import Fore, Style
+
+logger = logging.getLogger(__name__)
 
 _CACHE_FILE = os.path.expanduser("~/.embryo_crash_log.json")
 
@@ -24,7 +27,7 @@ class CrashTracker:
             # Corrupted JSON: back it up and start fresh
             backup = _CACHE_FILE + ".bak"
             os.replace(_CACHE_FILE, backup)
-            print(f"{Fore.YELLOW}[CRASH TRACKER] Corrupted log; backed up to {backup}{Style.RESET_ALL}")
+            logger.warning(f"[CRASH TRACKER] Corrupted log; backed up to {backup}")
             self.crashes = []
             # write a new empty log
             try:
@@ -33,7 +36,7 @@ class CrashTracker:
             except Exception:
                 pass
         except Exception as e:
-            print(f"{Fore.RED}[CRASH TRACKER] Failed to load crash log: {e}{Style.RESET_ALL}")
+            logger.error(f"[CRASH TRACKER] Failed to load crash log: {e}")
             self.crashes = []
 
     def _save(self):
@@ -41,7 +44,7 @@ class CrashTracker:
             with open(_CACHE_FILE, 'w', encoding='utf-8') as f:
                 json.dump(self.crashes, f, indent=2)
         except Exception as e:
-            print(f"{Fore.RED}[CRASH TRACKER] Failed to save crash log: {e}{Style.RESET_ALL}")
+            logger.error(f"[CRASH TRACKER] Failed to save crash log: {e}")
 
     def record_crash(self, goal: str, phase: str, context: dict = None):
         event = {
@@ -52,7 +55,7 @@ class CrashTracker:
         }
         self.crashes.append(event)
         self._save()
-        print(f"{Fore.RED}[CRASH] Logged fatal event: {goal} during {phase} — {event['context']}{Style.RESET_ALL}")
+        logger.error(f"[CRASH] Logged fatal event: {goal} during {phase} — {event['context']}")
 
     def log_crash(self, context: dict):
         goal  = context.get("goal",  "unknown")
@@ -74,7 +77,7 @@ class CrashTracker:
     def clear(self):
         self.crashes = []
         self._save()
-        print(f"{Fore.YELLOW}[CRASH TRACKER] Cleared crash history{Style.RESET_ALL}")
+        logger.info("[CRASH TRACKER] Cleared crash history")
 
     # ─── NEW: Export to JSON ────────────────────────────────────────────
     def to_json(self) -> str:

--- a/Genesis_Monitor.py
+++ b/Genesis_Monitor.py
@@ -3,11 +3,14 @@
 
 import os
 import time
+import logging
 import dash
 from dash import dcc, html, Input, Output, State
 import dash_daq as daq
 import plotly.graph_objs as go
 import duckdb
+
+logger = logging.getLogger(__name__)
 import pandas as pd
 
 # ——— Configuration ———
@@ -252,6 +255,8 @@ def update_dashboard(n, selected_strategies, selected_gens):
 
 # ——— Main Runner ———
 if __name__ == '__main__':
+    from Logging_Config import configure_logging
+    configure_logging()
     if not os.path.isdir(PARQUET_DIR):
-        print(f"[WARN] Parquet directory not found: {PARQUET_DIR}")
+        logger.warning(f"[WARN] Parquet directory not found: {PARQUET_DIR}")
     app.run_server(debug=True)

--- a/Goals.py
+++ b/Goals.py
@@ -10,6 +10,8 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 import numpy as np
 from colorama import Fore, Style
+
+logger = logging.getLogger(__name__)
 import pickle
 from pathlib import Path
 
@@ -177,7 +179,7 @@ class GoalGenerator:
             if g.name in self.generated:
                 continue
             if not training and g.name in crash_goals:
-                print(f"{Fore.RED}[FILTER] Skipping crash-prone goal: {g.name}{Style.RESET_ALL}")
+                logger.warning(f"[FILTER] Skipping crash-prone goal: {g.name}")
                 continue
             filtered.append(g)
             self.generated.add(g.name)
@@ -301,7 +303,9 @@ class GoalEngine:
             limit=1
         )
         if crashes:
-            print(f"{Fore.RED}[CRASH PENALTY] Recent crash tied to '{self.current_goal}' — penalty applied{Style.RESET_ALL}")
+            logger.warning(
+                f"[CRASH PENALTY] Recent crash tied to '{self.current_goal}' — penalty applied"
+            )
             reward -= 0.5
 
         # Q-learning update

--- a/Health.py
+++ b/Health.py
@@ -6,6 +6,8 @@ import json
 import os
 from collections import deque
 from colorama import Fore, Style
+
+logger = logging.getLogger(__name__)
 from sklearn.preprocessing import MinMaxScaler
 import settings
 from typing import Dict, Any, Optional
@@ -36,8 +38,10 @@ def calibrate_max_io() -> float:
 
 # If running as a script, calibrate once
 if __name__ == '__main__':
+    from Logging_Config import configure_logging
+    configure_logging()
     MAX_IO_MBPS = calibrate_max_io()
-    print(f"{Fore.CYAN}[CALIBRATION] MAX_IO_MBPS = {MAX_IO_MBPS:.2f} MB/s{Style.RESET_ALL}")
+    logger.info(f"[CALIBRATION] MAX_IO_MBPS = {MAX_IO_MBPS:.2f} MB/s")
 
 
 # def collect_process_metrics() -> dict[int, dict]:

--- a/Merge_duckdb.py
+++ b/Merge_duckdb.py
@@ -1,5 +1,9 @@
 import duckdb
 import os
+import logging
+from Logging_Config import configure_logging
+
+logger = logging.getLogger(__name__)
 
 # 1) Point at your three source files
 src_files = [
@@ -14,25 +18,26 @@ if os.path.exists(target_db):
     os.remove(target_db)
 
 # 3) Discover table names by opening the first DB on its own
-print("Discovering tables in", src_files[0])
+configure_logging()
+logger.info(f"Discovering tables in {src_files[0]}")
 con0 = duckdb.connect(src_files[0])
 tables = [row[0] for row in con0.execute("SHOW TABLES;").fetchall()]
 con0.close()
 
 if not tables:
     raise RuntimeError(f"No tables found in {src_files[0]} – are you sure it has tables?")
-print("  Found tables:", tables)
+logger.info(f"Found tables: {tables}")
 
 # 4) Now open (and create) the target DB and attach all three sources
 con = duckdb.connect(target_db)
 for idx, fn in enumerate(src_files):
     schema = f"src{idx}"
     con.execute(f"ATTACH '{fn}' AS {schema};")
-    print(f"  Attached {fn} → schema {schema}")
+    logger.info(f"Attached {fn} -> schema {schema}")
 
 # 5) For each table, UNION ALL across src0, src1, src2
 for t in tables:
-    print(f"  Merging table `{t}`…")
+    logger.info(f"Merging table `{t}`…")
     union_sql = " UNION ALL ".join(f"SELECT * FROM src{idx}.{t}" for idx in range(len(src_files)))
     con.execute(f"CREATE TABLE {t} AS {union_sql};")
 
@@ -40,4 +45,4 @@ for t in tables:
 con.execute("VACUUM;")
 con.close()
 
-print(f"\n✅ Done!  Merged {len(tables)} tables into `{target_db}`")
+logger.info(f"Done! Merged {len(tables)} tables into `{target_db}`")

--- a/Pretrain_Critic.py
+++ b/Pretrain_Critic.py
@@ -4,7 +4,11 @@ import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
 import numpy as np
+import logging
 from Genesis_Embryo_Core import Critic
+from Logging_Config import configure_logging
+
+logger = logging.getLogger(__name__)
 
 # ←— point at the merged DB you just built ——
 DB_PATH         = 'godseed_training.db'
@@ -31,8 +35,8 @@ def load_transitions(db_path=DB_PATH):
     con.close()
 
     # sanity-check
-    print(f"  → Loaded {len(df)} transitions")
-    print(f"    time span: {df.ts.min()}  →  {df.ts.max()}")
+    logger.info(f"Loaded {len(df)} transitions")
+    logger.info(f"time span: {df.ts.min()} -> {df.ts.max()}")
     return df
 
 def pretrain_critic(df, critic, optimizer,
@@ -61,17 +65,18 @@ def pretrain_critic(df, critic, optimizer,
             optimizer.step()
             total_loss += loss.item() * s.size(0)
         avg_loss = total_loss / len(loader.dataset)
-        print(f'[Pretrain] Epoch {epoch}/{epochs}  Loss={avg_loss:.6f}')
+        logger.info(f'[Pretrain] Epoch {epoch}/{epochs}  Loss={avg_loss:.6f}')
     return critic
 
 def main():
+    configure_logging()
     df = load_transitions()
     critic    = Critic(input_dim=5, hidden=32)
     optimizer = optim.Adam(critic.parameters(), lr=LR)
 
     critic = pretrain_critic(df, critic, optimizer)
     torch.save(critic.state_dict(), 'critic_pretrained.pt')
-    print('[Pretrain] Saved pretrained weights to critic_pretrained.pt')
+    logger.info('Saved pretrained weights to critic_pretrained.pt')
 
 if __name__ == '__main__':
     main()

--- a/testing.py
+++ b/testing.py
@@ -1,2 +1,13 @@
 import psutil
-print(psutil.net_io_counters(pernic=False, nowrap=True))
+import logging
+from Logging_Config import configure_logging
+
+
+def main():
+    configure_logging()
+    logger = logging.getLogger(__name__)
+    logger.info(psutil.net_io_counters(pernic=False, nowrap=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace print debugging with logging across modules
- retain a single heartbeat print showing composite score
- call `configure_logging()` before using logging

## Testing
- `python -m py_compile CrashTracker.py Health.py testing.py Strategy.py Goals.py Genesis_Embryo_Core.py Pretrain_Critic.py Genesis_Monitor.py Merge_duckdb.py Mutation.py`

------
https://chatgpt.com/codex/tasks/task_e_684ca738bf5c8323bd37911497e93f3e