### PR TITLE
Use archive during mutation cycle

### DIFF
--- a/Genesis_Embryo_Core.py
+++ b/Genesis_Embryo_Core.py
@@ -1150,6 +1150,7 @@ class Embryo:
 
         # ─── Seed from archive at start of cycle ────────────────────────
         if hasattr(self.archive, "seed"):
+            logger.debug("[ARCHIVE] attempting seed from archive")
             self.archive.seed(self)
 
         # 0.1) ensure our embedding matches the new action_space size
@@ -1213,6 +1214,9 @@ class Embryo:
 
             # If we've been stuck for several cycles, replay the best state
             if self.bad_cycles >= self.rollback_required:
+                logger.info(
+                    f"[ARCHIVE] replaying best state after {self.bad_cycles} stagnant cycles"
+                )
                 if hasattr(self.archive, "replay_success"):
                     self.archive.replay_success(self)
 


### PR DESCRIPTION
## Summary
- add debug log when seeding from archive
- log replay trigger when the mutation cycle remains stuck

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cadbffd908323ae0dd42a2a2a4103