### PR TITLE
Add pytest tests and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ Contributions, bug reports, and feature requests are welcome! Please:
 4. Push to your branch (`git push origin feature/YourFeature`)
 5. Open a Pull Request
 
+## 🧪 Running Tests
+
+Install the dependencies (see Installation above) and then execute:
+
+```bash
+pytest
+```
+
+
 ## 📜 License
 
 This project is released under the MIT License. See `LICENSE` for details.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure project root is on sys.path
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_dynamic_resource_manager.py
+++ b/tests/test_dynamic_resource_manager.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import psutil
+
+from Resources import DynamicResourceManager
+
+
+def test_safe_terminate_kills_process():
+    drm = DynamicResourceManager()
+    proc = subprocess.Popen([psutil.Process().exe(), "-c", "import time; time.sleep(5)"])
+    try:
+        assert psutil.pid_exists(proc.pid)
+        assert drm.safe_terminate(proc.pid)
+        assert not psutil.pid_exists(proc.pid)
+    finally:
+        if psutil.pid_exists(proc.pid):
+            psutil.Process(proc.pid).kill()
+
+
+def test_safe_terminate_respects_whitelist_and_blacklist():
+    drm = DynamicResourceManager()
+    drm.whitelist.add(os.getpid())
+    assert not drm.safe_terminate(os.getpid())
+
+    proc = subprocess.Popen([psutil.Process().exe(), "-c", "import time; time.sleep(5)"])
+    try:
+        name = psutil.Process(proc.pid).name()
+        drm.blacklist.add(name)
+        assert not drm.safe_terminate(proc.pid)
+        assert psutil.pid_exists(proc.pid)
+    finally:
+        if psutil.pid_exists(proc.pid):
+            psutil.Process(proc.pid).kill()

--- a/tests/test_mutation_cycle.py
+++ b/tests/test_mutation_cycle.py
@@ -1,0 +1,51 @@
+import types
+import pytest
+
+import Mutation
+import Health
+
+class DummyStrategy:
+    def apply(self, embryo):
+        old = getattr(embryo, "val", 0)
+        setattr(embryo, "val", old + 1)
+        return "inc", {"param": "val", "old": old, "new": old + 1}
+
+class DummyMutator:
+    def pick_strategy(self, meta_weights, is_stuck):
+        return "gaussian", DummyStrategy()
+
+class DummyDB:
+    def __init__(self):
+        self.last = None
+    def record_mutation_context(self, **kwargs):
+        self.last = kwargs
+
+class DummyEmbryo:
+    def __init__(self):
+        self.val = 0
+        self.mutator = DummyMutator()
+        self.db = DummyDB()
+
+
+def test_mutation_cycle_updates_score_and_weights(monkeypatch):
+    metrics_seq = [
+        {"composite": 0.5, "cpu": 0, "memory": 0, "disk": 0, "network": 0},
+        {"composite": 0.6, "cpu": 0, "memory": 0, "disk": 0, "network": 0},
+    ]
+    def fake_check():
+        return metrics_seq.pop(0)
+    monkeypatch.setattr(Health.SystemHealth, "check", staticmethod(fake_check))
+    monkeypatch.setattr(Health.Survival, "score", lambda m: m)
+
+    embryo = DummyEmbryo()
+    meta = {"gaussian": 1.0, "reset": 0.0}
+
+    new_score, new_stagnant, strategy = Mutation.mutation_cycle(
+        embryo, meta, stagnant_cycles=0, return_strategy=True
+    )
+
+    assert new_score == pytest.approx(0.6)
+    assert new_stagnant == 0
+    assert strategy == "gaussian"
+    assert embryo.val == 1
+    assert meta["gaussian"] > 0.9

--- a/tests/test_weight_manager.py
+++ b/tests/test_weight_manager.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+from WeightManager import WeightManager
+
+
+def test_update_adjusts_weights_and_history():
+    wm = WeightManager(init_weights=[0.25, 0.25, 0.25, 0.25], lr=0.1)
+    metrics = np.array([1.0, 0.0, 0.0, 0.0])
+    wm.update(metrics, reward_delta=1.0)
+    weights = wm.get_weights()
+    assert pytest.approx(weights.sum(), rel=1e-6) == 1.0
+    assert weights[0] > 0.25
+    assert len(wm.history) == 1
+
+
+def test_update_mutation_probs_normalizes_and_clamps():
+    wm = WeightManager(lr=0.5)
+    wm.update_mutation_probs("gaussian", reward_delta=1.0)
+    probs = wm.get_mutation_probs()
+    assert pytest.approx(sum(probs.values()), rel=1e-6) == 1.0
+    assert probs["gaussian"] > 0.0
+
+    wm.update_mutation_probs("gaussian", reward_delta=-10.0)
+    probs = wm.get_mutation_probs()
+    assert probs["gaussian"] >= 0.0


### PR DESCRIPTION
## Summary
- add unit tests for WeightManager, mutation_cycle, and DynamicResourceManager
- ensure project root on `sys.path` for tests
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb4653ebc832398502bb7618d8ce2