### PR TITLE
Add gradient clipping support to World Model trainer

### DIFF
--- a/Genesis_Embryo_Core.py
+++ b/Genesis_Embryo_Core.py
@@ -46,6 +46,7 @@ from MemoryOptimizer import EfficientStateManager, TimeSimEngine, MemoryAIManage
 from Persistence import MemoryArchive, MemoryDB, SnapshotManager, DuckdbStateIO
 from Meta_Strategy_Engine import MetaStrategyEngine
 from Logging_Config import configure_logging
+import settings
 
 from multiprocessing import current_process
 
@@ -572,6 +573,7 @@ class Embryo:
         choice_emb_dim = int(self.cfg.get("world_model_choice_dim", 8))
         hidden_dim     = int(self.cfg.get("world_model_hidden", 128))
         learning_rate  = float(self.cfg.get("world_model_lr", 1e-3))
+        grad_clip      = self.cfg.get("world_model_grad_clip", settings.WORLD_MODEL_GRAD_CLIP)
 
         # (b) Build a single WorldModel instance and move to device:
         self.world_model = WorldModel(state_dim, choice_emb_dim, hidden_dim).to(self.device)
@@ -579,7 +581,8 @@ class Embryo:
         # (c) Instantiate the WorldModelTrainer on exactly that same instance:
         self.world_trainer = WorldModelTrainer(
             self.world_model,
-            lr=learning_rate
+            lr=learning_rate,
+            grad_clip=grad_clip
         )
 
         # ─── NOW that choice_emb_dim is in scope, build the action_embedding ──

--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "rollback_required_cycles": 2,
     "exploration_base": 0.2,
     "dynamic_strategy_prob": 0.01,
+    "world_model_grad_clip": 1.0,
     "metrics_interval": 5,
     "target_ram_usage_pct": 95.0,
     "snapshot_ram_threshold_pct": 50.0,

--- a/settings.py
+++ b/settings.py
@@ -3,3 +3,7 @@ IO_CALIBRATION_SIZE_MB = 100 # bytes to write for I/O calibration
 INTERVAL_SECONDS = 0.1
 MAX_NET_MB_S = 100.0
 MAX_IO_MBPS = 177.0
+
+# Default gradient clipping value for world model training.
+# Set to None to disable clipping.
+WORLD_MODEL_GRAD_CLIP = 1.0


### PR DESCRIPTION
## Summary
- optionally clip gradients when training the world model
- expose gradient clipping config value
- wire the config into `Genesis_Embryo_Core`
- document default value in `config.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_684cf14744d08323b74621c58b3e69f2