### PR TITLE
Add pygad mutation strategy with tests

### DIFF
--- a/Mutation.py
+++ b/Mutation.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Tuple, List, Callable, Optional, Union
 logger = logging.getLogger(__name__)
 from colorama import Fore, Style
 from Strategy import SynthStrategy, StrategyRegistry   # ← add SynthStrategy here
+from PyGAD_Strategy import pygad_mutation
 
 # Mutation strategies module
 
@@ -29,6 +30,7 @@ DEFAULT_META_WEIGHTS: Dict[str, float] = {
     "gaussian":       1.0,
     "random_uniform": 1.0,
     "creep":          1.0,
+    "pygad":         1.0,
     "reset":          0.0,
 }
 
@@ -336,7 +338,7 @@ class MutationEngine:
         meta_weights: Dict[str, float],
         is_stuck: bool
     ) -> Tuple[str, SynthStrategy]:
-        names = ["gaussian", "random_uniform", "creep"] + (['reset'] if is_stuck else [])
+        names = ["gaussian", "random_uniform", "creep", "pygad"] + (['reset'] if is_stuck else [])
         wts   = [meta_weights.get(n, 0.0) for n in names]
         total = sum(wts) or 1.0
         probs = [w/total for w in wts]
@@ -368,11 +370,12 @@ DEFAULT_STRATEGIES_MAP: Dict[str, Callable[..., Tuple[str, dict]]] = {
     "gaussian":       gaussian,
     "random_uniform": random_uniform,
     "creep":          creep,
+    "pygad":          pygad_mutation,
     "reset":          reset,
 }
 
 __all__ = [
-    "gaussian", "random_uniform", "creep", "reset",
+    "gaussian", "random_uniform", "creep", "pygad_mutation", "reset",
     "embryo_mutation", "mutation_cycle", "Archive", "MutationEngine",
     "DEFAULT_STRATEGIES_MAP",
 ]

--- a/PyGAD_Strategy.py
+++ b/PyGAD_Strategy.py
@@ -1,0 +1,60 @@
+"""PyGAD-based mutation strategy."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, Tuple, List
+
+import numpy as np
+import pygad
+
+
+def pygad_mutation(embryo: Any) -> Tuple[str, Dict[str, Any]]:
+    """Run a tiny GA to evolve a few embryo parameters."""
+    # Choose up to 3 parameters to evolve
+    params: List[str] = random.sample(embryo.mutator.params, k=min(3, len(embryo.mutator.params)))
+
+    gene_space = []
+    start_vals = []
+    for p in params:
+        lower, upper = embryo.param_bounds[p]
+        gene_space.append({'low': lower, 'high': upper})
+        start_vals.append(getattr(embryo, p))
+
+    def fitness_func(ga_inst, solution, sol_idx):
+        # simple objective: maximize sum of values
+        return float(np.sum(solution))
+
+    ga = pygad.GA(
+        num_generations=3,
+        sol_per_pop=5,
+        num_parents_mating=2,
+        num_genes=len(params),
+        gene_space=gene_space,
+        fitness_func=fitness_func,
+        mutation_percent_genes=50,
+    )
+    ga.run()
+    best_solution, _, _ = ga.best_solution()
+
+    desc_parts = []
+    ctx = {
+        'strategy': 'pygad',
+        'param': [],
+        'old': [],
+        'new': [],
+        'delta': []
+    }
+    for val, p, old in zip(best_solution, params, start_vals):
+        new_val = embryo.apply_param_bounds(p, val)
+        setattr(embryo, p, new_val)
+        desc_parts.append(f"{p}: {old:.3f} -> {new_val:.3f}")
+        ctx['param'].append(p)
+        ctx['old'].append(round(old, 4))
+        ctx['new'].append(round(new_val, 4))
+        ctx['delta'].append(round(new_val - old, 4))
+
+    desc = '; '.join(desc_parts)
+    return desc, ctx
+
+__all__ = ['pygad_mutation']

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scikit-learn
 colorama
 pydantic
 astor
+pygad>=3.3.1

--- a/tests/test_pygad_strategy.py
+++ b/tests/test_pygad_strategy.py
@@ -1,0 +1,21 @@
+import types
+
+import PyGAD_Strategy
+
+class DummyEmbryo:
+    def __init__(self):
+        self.param_bounds = {'x': (0.0, 2.0), 'y': (0.0, 2.0)}
+        self.x = 1.0
+        self.y = 1.0
+        self.mutator = types.SimpleNamespace(params=['x', 'y'])
+
+    def apply_param_bounds(self, param, value):
+        low, high = self.param_bounds[param]
+        return max(low, min(high, value))
+
+def test_pygad_mutation_alters_params():
+    embryo = DummyEmbryo()
+    before = (embryo.x, embryo.y)
+    desc, ctx = PyGAD_Strategy.pygad_mutation(embryo)
+    after = (embryo.x, embryo.y)
+    assert after != before


### PR DESCRIPTION
## Summary
- add `pygad>=3.3.1` requirement
- implement new `pygad_mutation` strategy powered by PyGAD
- register the PyGAD strategy in default strategy maps and pick logic
- unit tests for the new strategy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cf2f574e08323a573b734df3aa460