### PR TITLE
Fix deepcopy skip list & add test

### DIFF
--- a/Genesis_Embryo_Core.py
+++ b/Genesis_Embryo_Core.py
@@ -698,23 +698,20 @@ class Embryo:
         new = cls.__new__(cls)
 
         # 1) Shallow-copy the long-lived/non-pickleable resources:
-        for attr in (
+        skip_attrs = (
             'db', 'snap_mgr', 'state_manager', 'duckdb_state_io',
             'world_model', 'world_trainer', 'action_embedding',
             'critic', 'goal_engine', 'goal_gen', 'health',
-            '_log_pool', 'resource_manager'
-        ):
+            '_log_pool', 'resource_manager',
+            'mutator', 'meta_engine', 'weight_mgr', 'CrashTracker'
+        )
+        for attr in skip_attrs:
             if hasattr(self, attr):
                 setattr(new, attr, getattr(self, attr))
 
         # 2) Deep-copy everything else into the new instance:
         for key, val in self.__dict__.items():
-            if key not in (
-                'db', 'snap_mgr', 'state_manager', 'duckdb_state_io',
-                'world_model', 'world_trainer', 'action_embedding',
-                'critic', 'goal_engine', 'goal_gen', 'health',
-                '_log_pool', 'resource_manager'
-            ):
+            if key not in skip_attrs:
                 setattr(new, key, copy.deepcopy(val, memo))
 
         return new

--- a/tests/test_embryo_deepcopy.py
+++ b/tests/test_embryo_deepcopy.py
@@ -1,0 +1,12 @@
+import copy
+import pytest
+
+from Genesis_Embryo_Core import Embryo, cfg_mgr
+
+
+def test_embryo_deepcopy_succeeds(tmp_path):
+    pytest.importorskip("torch")
+    db_path = tmp_path / "embryo.db"
+    embryo = Embryo(cfg_mgr, db_path=str(db_path), disable_snapshots=True)
+    clone = copy.deepcopy(embryo)
+    assert isinstance(clone, Embryo)


### PR DESCRIPTION
## Summary
- avoid copying MutationEngine, CrashTracker, and related objects
- test that Embryo instances can be deep copied

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684da6e2b1948323ba1b9ec516c76473