### PR TITLE
Fix pygad list context handling

### DIFF
--- a/Health.py
+++ b/Health.py
@@ -186,8 +186,12 @@ class SystemHealth:
         with proc.oneshot():
             cpu = proc.cpu_percent(None)
             memory = proc.memory_percent()
-            io_counters = proc.io_counters()  # namedtuple(read_bytes, write_bytes, ...)
-        read_bytes, write_bytes = io_counters.read_bytes, io_counters.write_bytes
+            try:
+                io_counters = proc.io_counters()  # namedtuple(read_bytes, write_bytes, ...)
+                read_bytes, write_bytes = io_counters.read_bytes, io_counters.write_bytes
+            except AttributeError:
+                # Some psutil implementations lack io_counters
+                read_bytes = write_bytes = 0
 
         # ─── 2) COLLECT STATIC METRICS (e.g. disk, load) ─────────────
         metrics: Dict[str, Any] = {}

--- a/Mutation.py
+++ b/Mutation.py
@@ -163,18 +163,43 @@ def mutation_cycle(
     scored_after = Survival.score(raw_after)
     new_score = scored_after["composite"]
 
-    embryo.db.record_mutation_context(
-        param=ctx["param"],
-        strategy=choice,
-        old=ctx.get("old", 0.0),
-        new=ctx.get("new", 0.0),
-        before=before_score,
-        after=new_score,
-        cpu=scored_after["cpu"],
-        mem=scored_after["memory"],
-        disk=scored_after["disk"],
-        network=scored_after.get("network", 0.0)
-    )
+    params = ctx.get("param")
+    olds = ctx.get("old", 0.0)
+    news = ctx.get("new", 0.0)
+
+    if isinstance(params, list) or isinstance(olds, list) or isinstance(news, list):
+        if not isinstance(params, list):
+            params = [params]
+        if not isinstance(olds, list):
+            olds = [olds] * len(params)
+        if not isinstance(news, list):
+            news = [news] * len(params)
+        for p, o, n in zip(params, olds, news):
+            embryo.db.record_mutation_context(
+                param=p,
+                strategy=choice,
+                old=o,
+                new=n,
+                before=before_score,
+                after=new_score,
+                cpu=scored_after["cpu"],
+                mem=scored_after["memory"],
+                disk=scored_after["disk"],
+                network=scored_after.get("network", 0.0)
+            )
+    else:
+        embryo.db.record_mutation_context(
+            param=params,
+            strategy=choice,
+            old=olds,
+            new=news,
+            before=before_score,
+            after=new_score,
+            cpu=scored_after["cpu"],
+            mem=scored_after["memory"],
+            disk=scored_after["disk"],
+            network=scored_after.get("network", 0.0)
+        )
     logger.info(f"[SCORE] before={before_score:.4f}, after={new_score:.4f}")
 
     # 4) Compute reward & update weights

--- a/tests/test_mutation_cycle.py
+++ b/tests/test_mutation_cycle.py
@@ -27,6 +27,54 @@ class DummyEmbryo:
         self.db = DummyDB()
 
 
+def test_pygad_mutation_records_each(monkeypatch):
+    metrics_seq = [
+        {"composite": 0.5, "cpu": 0, "memory": 0, "disk": 0, "network": 0},
+        {"composite": 0.6, "cpu": 0, "memory": 0, "disk": 0, "network": 0},
+    ]
+
+    def fake_check():
+        return metrics_seq.pop(0)
+
+    monkeypatch.setattr(Health.SystemHealth, "check", staticmethod(fake_check))
+    monkeypatch.setattr(Health.Survival, "score", lambda m: m)
+
+    import PyGAD_Strategy
+
+    class PygadMutator:
+        def __init__(self):
+            self.params = ["x", "y", "z"]
+        def pick_strategy(self, meta_weights, is_stuck):
+            return "pygad", types.SimpleNamespace(apply=PyGAD_Strategy.pygad_mutation)
+
+    class PygadEmbryo:
+        def __init__(self):
+            self.param_bounds = {"x": (0.0, 2.0), "y": (0.0, 2.0), "z": (0.0, 2.0)}
+            self.x = 1.0
+            self.y = 1.0
+            self.z = 1.0
+            self.mutator = PygadMutator()
+            self.db = types.SimpleNamespace(calls=[])
+            def rec(**kw):
+                self.db.calls.append(kw)
+            self.db.record_mutation_context = rec
+
+        def apply_param_bounds(self, param, value):
+            low, high = self.param_bounds[param]
+            return max(low, min(high, value))
+
+    monkeypatch.setattr(PyGAD_Strategy.random, "sample", lambda seq, k: list(seq)[:2])
+
+    embryo = PygadEmbryo()
+    meta = {"pygad": 1.0, "reset": 0.0}
+
+    Mutation.mutation_cycle(embryo, meta, stagnant_cycles=0)
+
+    assert len(embryo.db.calls) == 2
+    for call in embryo.db.calls:
+        assert not isinstance(call["param"], list)
+
+
 def test_mutation_cycle_updates_score_and_weights(monkeypatch):
     metrics_seq = [
         {"composite": 0.5, "cpu": 0, "memory": 0, "disk": 0, "network": 0},


### PR DESCRIPTION
## Summary
- ensure mutation cycle splits list contexts from pygad
- protect Health check when psutil lacks `io_counters`
- test recording of multi-parameter pygad mutations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da8e0d2188323b5817de448fc6ea6